### PR TITLE
[OCPCLOUD-1226] add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - JoelSpeed
+  - elmiko
+  - alexander-demichev
+  - lobziik
+  - Fedosin
+
+component: "Cloud Compute"
+subcomponent: "Other Providers"


### PR DESCRIPTION
this file is required for use by the OpenShift merge automation, see
the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
for more info.