### PR TITLE
[OCPCLOUD-1226] add ci-operator config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.15


### PR DESCRIPTION
This adds the `.ci-operator.yaml` file to the root of the repository,
this file is utilized by OpenShift automation to determine the base for
building this code.