### PR TITLE
Updating modules path to OpenShift.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
-WORKDIR /go/src/github.com/AliyunContainerService/cluster-api-provider-alibabacloud
+WORKDIR /go/src/github.com/openshift/cluster-api-provider-alibaba
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
   && GOPROXY=off NO_DOCKER=1 make build
 
 FROM registry.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/AliyunContainerService/cluster-api-provider-alibabacloud/bin/machine-controller-manager /
+COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-alibaba/bin/machine-controller-manager /

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,9 +1,9 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
-WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-alibabacloud
+WORKDIR /go/src/github.com/openshift/cluster-api-provider-alibaba
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
  && GOPROXY=off NO_DOCKER=1 make build
 
 FROM registry.ci.openshift.org/ocp/4.8:base
-COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-alibabacloud/bin/machine-controller-manager /
+COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-alibaba/bin/machine-controller-manager /

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOARCH  ?= $(shell go env GOARCH)
 GOOS    ?= $(shell go env GOOS)
 
 VERSION     ?= $(shell git describe --tags --abbrev=7)
-REPO_PATH   ?= github.com/AliyunContainerService/cluster-api-provider-alibabacloud
+REPO_PATH   ?= github.com/openshift/cluster-api-provider-alibaba
 LD_FLAGS    ?= -X $(REPO_PATH)/pkg/version.Raw=$(VERSION) $(shell hack/version.sh)  -extldflags "-static"
 MUTABLE_TAG ?= latest
 IMAGE        = origin-alibabacloud-machine-controllers
@@ -60,7 +60,7 @@ ifeq ($(NO_DOCKER), 1)
   DOCKER_CMD =
   IMAGE_BUILD_CMD = imagebuilder
 else
-  DOCKER_CMD = $(ENGINE) run --rm -e CGO_ENABLED=$(CGO_ENABLED) -e GOARCH=$(GOARCH) -e GOOS=$(GOOS) -v "$(PWD)":/go/src/github.com/AliyunContainerService/cluster-api-provider-alibabacloud:Z -w /go/src/github.com/AliyunContainerService/cluster-api-provider-alibabacloud openshift/origin-release:golang-1.16
+  DOCKER_CMD = $(ENGINE) run --rm -e CGO_ENABLED=$(CGO_ENABLED) -e GOARCH=$(GOARCH) -e GOOS=$(GOOS) -v "$(PWD)":/go/src/github.com/openshift/cluster-api-provider-alibaba:Z -w /go/src/github.com/openshift/cluster-api-provider-alibaba openshift/origin-release:golang-1.16
   IMAGE_BUILD_CMD = $(ENGINE) build
 endif
 
@@ -123,7 +123,7 @@ test-e2e: ## Run e2e tests
 
 .PHONY: lint
 lint: ## Go lint your code
-	$(DOCKER_CMD) hack/go-lint.sh -min_confidence 0.3 $$(go list -f '{{ .ImportPath }}' ./... | grep -v -e 'github.com/AliyunContainerService/cluster-api-provider-alibabacloud/test' -e 'github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/cloud/alibabacloud/client/mock')
+	$(DOCKER_CMD) hack/go-lint.sh -min_confidence 0.3 $$(go list -f '{{ .ImportPath }}' ./... | grep -v -e 'github.com/openshift/cluster-api-provider-alibaba/test' -e 'github.com/openshift/cluster-api-provider-alibaba/pkg/cloud/alibabacloud/client/mock')
 
 .PHONY: fmt
 fmt: ## Go fmt your code

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Note: this info is RH only, it needs to be backported every time the `README.md`
 2. **Build and run AlibabaCloud actuator outside of the cluster**
 
    ```sh
-   $ go build -o bin/machine-controller-manager github.com/AliyunContainerService/cluster-api-provider-alibabacloud/cmd/manager
+   $ go build -o bin/machine-controller-manager github.com/openshift/cluster-api-provider-alibaba/cmd/manager
    ```
 
    ```sh
@@ -342,10 +342,3 @@ Note: this info is RH only, it needs to be backported every time the `README.md`
    ```sh
    $ kubectl  get machine
    ```
- 
-# Upstream Implementation
-Other branches of this repository may choose to track the upstream
-Kubernetes [Cluster-API AlibabaCloud provider](https://github.com/AliyunContainerService/cluster-api-provider-alibabacloud)
-
-In the future, we may align the master branch with the upstream project as it
-stabilizes within the community.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/version"
+	"github.com/openshift/cluster-api-provider-alibaba/pkg/version"
 
 	"github.com/openshift/machine-api-operator/pkg/metrics"
 
@@ -29,15 +29,15 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	actuator "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/actuators/machine"
-	alibabacloudClient "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/client"
+	actuator "github.com/openshift/cluster-api-provider-alibaba/pkg/actuators/machine"
+	alibabacloudClient "github.com/openshift/cluster-api-provider-alibaba/pkg/client"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
-	machineactuator "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/actuators/machine"
-	machinesetcontroller "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/actuators/machineset"
-	"github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis"
 	configv1 "github.com/openshift/api/config/v1"
+	machineactuator "github.com/openshift/cluster-api-provider-alibaba/pkg/actuators/machine"
+	machinesetcontroller "github.com/openshift/cluster-api-provider-alibaba/pkg/actuators/machineset"
+	"github.com/openshift/cluster-api-provider-alibaba/pkg/apis"
 	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/controller/machine"
 	"k8s.io/klog/v2"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AliyunContainerService/cluster-api-provider-alibabacloud
+module github.com/openshift/cluster-api-provider-alibaba
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -59,7 +59,6 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -795,7 +794,6 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
-go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.8.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -1225,7 +1223,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.18.0-beta.2/go.mod h1:2oeNnWEqcSmaM/ibSh3t7xcIqbkGXhzZdn4ezV9T4m0=

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -80,7 +80,7 @@ version::ldflags() {
         local key=${1}
         local val=${2}
         ldflags+=(
-            "-X 'github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/version.${key}=${val}'"
+            "-X 'github.com/openshift/cluster-api-provider-alibaba/pkg/version.${key}=${val}'"
         )
     }
 

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -19,7 +19,7 @@ package machine
 import (
 	"context"
 
-	alibabacloudClient "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/client"
+	alibabacloudClient "github.com/openshift/cluster-api-provider-alibaba/pkg/client"
 
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machineapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"

--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -28,8 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/client/mock"
 	"github.com/golang/mock/gomock"
+	"github.com/openshift/cluster-api-provider-alibaba/pkg/client/mock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	machineapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"

--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -29,11 +29,11 @@ import (
 	"k8s.io/klog"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	mapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
 
-	alibabacloudproviderv1 "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
-	alibabacloudClient "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/client"
-	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	alibabacloudproviderv1 "github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudprovider/v1beta1"
+	alibabacloudClient "github.com/openshift/cluster-api-provider-alibaba/pkg/client"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 
-	alibabacloudproviderv1 "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
-	v1beta1 "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
-	alibabacloudClient "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/client"
+	alibabacloudClient "github.com/openshift/cluster-api-provider-alibaba/pkg/client"
+
+	v1beta1 "github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudprovider/v1beta1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machineapierros "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -100,7 +100,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 func (s *machineScope) patchMachine() error {
 	klog.V(3).Infof("%v: patching machine", s.machine.GetName())
 
-	providerStatus, err := alibabacloudproviderv1.RawExtensionFromProviderStatus(s.providerStatus)
+	providerStatus, err := v1beta1.RawExtensionFromProviderStatus(s.providerStatus)
 	if err != nil {
 		return machineapierros.InvalidMachineConfiguration("failed to get machine provider status: %v", err)
 	}
@@ -151,7 +151,7 @@ func (s *machineScope) getUserData() (string, error) {
 	return base64.StdEncoding.EncodeToString(userData), nil
 }
 
-func (s *machineScope) setProviderStatus(instance *ecs.Instance, condition alibabacloudproviderv1.AlibabaCloudMachineProviderCondition) error {
+func (s *machineScope) setProviderStatus(instance *ecs.Instance, condition v1beta1.AlibabaCloudMachineProviderCondition) error {
 	klog.Infof("%s: Updating status", s.machine.Name)
 
 	// assign value to providerStatus

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -12,7 +12,7 @@ import (
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 
-	alibabacloudproviderv1 "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
+	alibabacloudproviderv1 "github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudprovider/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	alibabacloudproviderv1 "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
+	alibabacloudproviderv1 "github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudprovider/v1beta1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/actuators/machineset/controller.go
+++ b/pkg/actuators/machineset/controller.go
@@ -24,8 +24,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	alibabacloudproviderv1 "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
 	"github.com/go-logr/logr"
+	alibabacloudproviderv1 "github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudprovider/v1beta1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	mapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/actuators/machineset/ecs_instance_types.go
+++ b/pkg/actuators/machineset/ecs_instance_types.go
@@ -16,9 +16,9 @@ package machineset
 import (
 	"fmt"
 
-	alibabacloudproviderv1 "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
-	alibabacloudClient "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/client"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	alibabacloudproviderv1 "github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudprovider/v1beta1"
+	alibabacloudClient "github.com/openshift/cluster-api-provider-alibaba/pkg/client"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"k8s.io/klog"
 )

--- a/pkg/apis/addtoscheme_alibabacloudprovider_v1beta1.go
+++ b/pkg/apis/addtoscheme_alibabacloudprovider_v1beta1.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package apis
 
-import "github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudprovider/v1beta1"
+import "github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudprovider/v1beta1"
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back

--- a/pkg/apis/alibabacloudprovider/v1beta1/doc.go
+++ b/pkg/apis/alibabacloudprovider/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package v1beta1 contains API Schema definitions for the alibabacloudmachineproviderconfig v1beta1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudmachineproviderconfig
+// +k8s:conversion-gen=github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudmachineproviderconfig
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=alibabacloudmachineproviderconfig.openshift.io
 package v1beta1

--- a/pkg/apis/alibabacloudprovider/v1beta1/register.go
+++ b/pkg/apis/alibabacloudprovider/v1beta1/register.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package v1beta1 contains API Schema definitions for the alibabacloudmachineproviderconfig v1beta1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-alibabacloud/pkg/apis/alibabacloudmachineproviderconfig
+// +k8s:conversion-gen=github.com/openshift/cluster-api-provider-alibaba/pkg/apis/alibabacloudmachineproviderconfig
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=alibabacloudmachineproviderconfig.openshift.io
 package v1beta1

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/utils"
+	"github.com/openshift/cluster-api-provider-alibaba/pkg/utils"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 
 	"k8s.io/klog/v2"
 
-	"github.com/AliyunContainerService/cluster-api-provider-alibabacloud/pkg/version"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/openshift/cluster-api-provider-alibaba/pkg/version"
 	machineapiapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	corev1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,8 +26,8 @@ import (
 // AlibabaCloudClientBuilderFunc is function type for building alibabacloud client
 type AlibabaCloudClientBuilderFunc func(client client.Client, secretName, namespace, region string, configManagedClient client.Client) (Client, error)
 
-// machineProviderUserAgent is a named handler that will add cluster-api-provider-alibabacloud
-var machineProviderUserAgent = fmt.Sprintf("openshift.io cluster-api-provider-alibabacloud:%s", version.Version.String())
+// machineProviderUserAgent is a named handler that will add cluster-api-provider-alibaba
+var machineProviderUserAgent = fmt.Sprintf("openshift.io cluster-api-provider-alibaba:%s", version.Version.String())
 
 const (
 	kubeAccessKeyID           = "accessKeyID"


### PR DESCRIPTION
Alibaba and Red Hat have agreed that this repository will be the core repository for the machine api. 

The work here is to update Alibaba's go.mod file to point to OpenShift and fix the library references. This should facilitate testing and align ourselves with our upcoming api refactor.