### PR TITLE
Ensure HOME is set for cache setup

### DIFF
--- a/hack/fetch-ext-bins.sh
+++ b/hack/fetch-ext-bins.sh
@@ -114,4 +114,10 @@ function setup_envs {
   export TEST_ASSET_ETCD=/tmp/kubebuilder/bin/etcd
   export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=10m
   export NO_DOCKER=1
+
+  # Ensure that some home var is set and that it's not the root
+  export HOME=${HOME:=/tmp/kubebuilder-testing}
+  if [ $HOME == "/" ]; then
+    export HOME=/tmp/kubebuilder-testing
+  fi
 }


### PR DESCRIPTION
When the HOME directory is unset or is set to /, kubebuilder tries to
create a cache directory but fails. Make sure in these cases that we set
it to a temp folder so that the test can create its cache.

This mimics what we already do in other providers repos.