### PR TITLE
Bug 2047693:[Alibaba] Remove code from getSecurityGroupIDByTags

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -390,12 +390,6 @@ func getSecurityGroupIDByTags(machine runtimeclient.ObjectKey, machineProviderCo
 	}
 	request := ecs.CreateDescribeSecurityGroupsRequest()
 	request.VpcId = machineProviderConfig.VpcID
-	if groupId, err := getResourceGroupId(machine, machineProviderConfig, client); err != nil {
-		klog.Errorf("Unable to determine resource group ID for machine %q, err %q", machine.Name, err)
-		return nil, mapierrors.InvalidMachineConfiguration("Unable to determine resource group ID for machine: %q", machine.Name)
-	} else {
-		request.ResourceGroupId = groupId
-	}
 	request.RegionId = machineProviderConfig.RegionID
 	request.Tag = buildDescribeSecurityGroupsTag(*tags)
 	request.Scheme = "https"


### PR DESCRIPTION
Each time a security group is created, the Tag is unique. I think it's not I don't think specifying resource groups is necessary.