### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -15,6 +15,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         api: clusterapi
         k8s-app: controller


### PR DESCRIPTION
References:
- [SCC docs](https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html)
- [SCC pinning docs](https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth)