### PR TITLE
OCPBUGS-44242: change the VERSION makefile variable to use OS_GIT_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ endif
 GOARCH  ?= $(shell go env GOARCH)
 GOOS    ?= $(shell go env GOOS)
 
-VERSION     ?= $(shell git describe --tags --abbrev=7)
+# if we don't have a supplied version, try to use the commit tag
+OS_GIT_VERSION ?= $(shell git describe --tags --abbrev=7)
+VERSION     ?= $(OS_GIT_VERSION)
 REPO_PATH   ?= github.com/openshift/cluster-api-provider-alibaba
 LD_FLAGS    ?= -X $(REPO_PATH)/pkg/version.Raw=$(VERSION) $(shell hack/version.sh)  -extldflags "-static"
 MUTABLE_TAG ?= latest


### PR DESCRIPTION
this change is being made to resolve an issue while processing images for openshift.