### PR TITLE
CNF-23376: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -642,7 +641,7 @@ func fetchCredentialsIniFromSecret(secret *corev1.Secret) (auth.Credential, erro
 	if !ok {
 		return nil, fmt.Errorf("failed to fetch key 'credentials' in secret data")
 	}
-	f, err := ioutil.TempFile("", "alibaba-creds-*")
+	f, err := os.CreateTemp("", "alibaba-creds-*")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

- Replaced usage of `ioutil.TempFile` with `os.CreateTemp` in the `fetchCredentialsIniFromSecret` function to align with modern Go best practices.
- Removed the unnecessary import of the deprecated `ioutil` package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code quality and maintainability through dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->